### PR TITLE
Minor: type of infer_simp_type updated.

### DIFF
--- a/hw2_inference.mli
+++ b/hw2_inference.mli
@@ -1,7 +1,7 @@
 open Hw1
 
 type simp_type = S_Elem of string | S_Arrow of simp_type * simp_type
-val infer_simp_type : lambda -> ((string * simp_type list) * simp_type) option
+val infer_simp_type : lambda -> ((string * simp_type) list * simp_type) option
 
 type hm_lambda = HM_Var of string | HM_Abs of string * lambda | HM_App of lambda * lambda | HM_Let of string * lambda * lambda
 type hm_type = HM_Elem of string | HM_Arrow of hm_type * hm_type | HM_ForAll of string * hm_type


### PR DESCRIPTION
It seems like the previous version was incorrect. It was changed according to common sense.